### PR TITLE
Enable operator password

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   # verify idempotence
   - idempotence=$(mktemp)
   - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml | tee -a ${idempotence}
-  - "tail ${idempotence} | grep -q 'changed=2.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)"
+  - "tail ${idempotence} | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)"
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ script:
   # verify idempotence
   - idempotence=$(mktemp)
   - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml | tee -a ${idempotence}
-  - "tail ${idempotence} | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)"
+    # for some reason, the timezone setting isn't idempotent in that docker container but it is in real life
+  - "tail ${idempotence} | grep -q 'changed=2.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)"
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Role Variables
 Variable name | Default value | Purpose
 --- | --- | ---
 `base__operator_username` | `user` | username for the account that will be used to log into the server etc.
+`base__operator_password` | `changeme` | password for the operator account. **Not secure by default, override it!**
 `base__provisioning_username` | `ansible` | username for the account that ansible will use
 `base__ssh_pubkey_path` | `~/.ssh/id_rsa.pub` | path to the public key to be inserted into `authorized_keys` for both users
 `base__timezone` | `America/Toronto` | the timezone to be used on the machine
@@ -25,17 +26,25 @@ Variable name | Default value | Purpose
 Dependencies
 ------------
 
-TBD
+Same as Ansible
 
 Example Playbook
 ----------------
 
+`playbook.yml`:
 ```yaml
 ---
 - hosts: all
   become: true
   roles:
     - ansible-role-base
+  include:
+    - myvars.yml # to override the default **insecure** operator password
+```
+
+`myvars.yml`:
+```yaml
+base__operator_password: 'my_$ecure_password!'
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Example Playbook
 base__operator_password: 'my_$ecure_password!'
 ```
 
+> Note: If the target system requires a password for SSH and/or sudo, run the
+> playbook with both the `-k` and `-K` options.
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Example Playbook
   become: true
   roles:
     - ansible-role-base
-  include:
+  vars_files:
     - myvars.yml # to override the default **insecure** operator password
 ```
 
 `myvars.yml`:
 ```yaml
-base__operator_password: 'my_$ecure_password!'
+base__operator_password: 'my_$ecure_password!' # Generate with `mkpasswd --method=sha-512`, and encrypt with vault
 ```
 
 > Note: If the target system requires a password for SSH and/or sudo, run the

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 base__provisioning_username: 'ansible'
 base__operator_username: 'user'
+base__operator_password: 'changeme'
 base__ssh_pubkey_path: '~/.ssh/id_rsa.pub'
 base__timezone: 'America/Toronto' # list at https://www.vmware.com/support/developer/vc-sdk/visdk400pubs/ReferenceGuide/timezone.html

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 base__provisioning_username: 'ansible'
 base__operator_username: 'user'
-base__operator_password: 'changeme'
+base__operator_password: '$6$.HUM4rnqj6Vi4js$YnMd/3nDQ/RLbp7bVDCbZHlo4qpvbk0RWS9nJqHjwVq1xNFJJBnhZc1gfCtukpR0yDrdPSrs52gJaYIm6Omgo1'
 base__ssh_pubkey_path: '~/.ssh/id_rsa.pub'
 base__timezone: 'America/Toronto' # list at https://www.vmware.com/support/developer/vc-sdk/visdk400pubs/ReferenceGuide/timezone.html

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -12,19 +12,16 @@
 
 - name: Create users and disable passwords
   user:
-    name: "{{ item }}"
-    password: "!!"
+    name: "{{ item.username }}"
+    password: "{{ item.password }}"
     state: present
   with_items:
-    - root
-    - "{{ base__provisioning_username }}"
-    - "{{ base__operator_username }}"
-
-- name: Set a password for operator account
-  user:
-    name: "{{ base__operator_username }}"
-    password:
-    state: present
+    - username: root
+      password: "!!"
+    - username: "{{ base__provisioning_username }}"
+      password: "!!"
+    - username: "{{ base__operator_username }}"
+      password: "{{ base__operator_password }}"
 
 - name: Add public keys
   authorized_key:

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,23 +1,4 @@
 ---
-- name: Create users and disable passwords
-  user:
-    name: "{{ item }}"
-    password: "!!"
-    state: present
-  with_items:
-    - root
-    - "{{ base__provisioning_username }}"
-    - "{{ base__operator_username }}"
-
-- name: Add public keys
-  authorized_key:
-    user: "{{ item }}"
-    state: present
-    key: "{{ lookup('file', base__ssh_pubkey_path) }}"
-  with_items:
-    - "{{ base__provisioning_username }}"
-    - "{{ base__operator_username }}"
-
 - name: Enable passwordless sudo
   lineinfile:
     path: /etc/sudoers
@@ -28,3 +9,29 @@
   with_items:
     - "{{ base__provisioning_username }}"
     - "{{ base__operator_username }}"
+
+- name: Create users and disable passwords
+  user:
+    name: "{{ item }}"
+    password: "!!"
+    state: present
+  with_items:
+    - root
+    - "{{ base__provisioning_username }}"
+    - "{{ base__operator_username }}"
+
+- name: Set a password for operator account
+  user:
+    name: "{{ base__operator_username }}"
+    password:
+    state: present
+
+- name: Add public keys
+  authorized_key:
+    user: "{{ item }}"
+    state: present
+    key: "{{ lookup('file', base__ssh_pubkey_path) }}"
+  with_items:
+    - "{{ base__provisioning_username }}"
+    - "{{ base__operator_username }}"
+


### PR DESCRIPTION
If none of the accounts have a password, it is impossible to login on a physical terminal when SSH is down.

Passwordless sudo moved up in the tasks to avoid a broken system without a working sudo if users' password setting fails.